### PR TITLE
Setup continuous integration with gitlab-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,17 @@
+image: golang
+
+stages:
+  - test
+
+before_script:
+  - pwd
+  - mkdir -p /go/src/github.com
+  - ln -s /builds/gustavotero7 /go/src/github.com/gustavotero7
+
+coverage:
+  stage: test
+  script:
+    - pwd
+    - cd /go/src/github.com/gustavotero7/go-conekta
+    - go get ./...
+    - go test $(go list ./... | grep -v /vendor/) -v -coverprofile .testCoverage.txt

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 
+
+[![pipeline status](https://gitlab.com/gustavotero7/go-conekta/badges/feature/setup-ci/pipeline.svg)](https://gitlab.com/gustavotero7/go-conekta/commits/feature/setup-ci) [![coverage report](https://gitlab.com/gustavotero7/go-conekta/badges/feature/setup-ci/coverage.svg)](https://gitlab.com/gustavotero7/go-conekta/commits/feature/setup-ci)
+
 ### Go-Conekta
 A Wrapper for use conekta's api v2 in golang inspired in [sait/go-conekta](https://github.com/sait/go-conekta)
 

--- a/client/client.go
+++ b/client/client.go
@@ -77,6 +77,7 @@ func (c *client) send(method, path string, v interface{}) ([]byte, error) {
 	req.Header.Add("content-type", "application/json")
 	req.SetBasicAuth(c.apiKey, "")
 
+	log.Printf("Calling %s\n", req.URL.String())
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -101,5 +102,4 @@ func (c *client) send(method, path string, v interface{}) ([]byte, error) {
 // For now this is only used for testing purposes
 func SetClientURL(apiURL string) {
 	getClient().apiURL = apiURL
-	log.Println("Client mocked")
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -16,10 +16,12 @@ func MockClient(apiURL string) {
 }
 
 var (
-	s = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
-		w.Write([]byte("Hi"))
-	}))
+	s = func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+			w.Write([]byte("Hi"))
+		}))
+	}
 )
 
 func Test_getClient(t *testing.T) {
@@ -55,7 +57,7 @@ func TestGet(t *testing.T) {
 	}{
 		{
 			name:    "OK",
-			url:     s.URL,
+			url:     s().URL,
 			path:    "/",
 			want:    []byte("Hi"),
 			wantErr: false,
@@ -68,15 +70,8 @@ func TestGet(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "No server",
-			url:     "http://xxx.xxx.xxx",
-			path:    "/",
-			want:    nil,
-			wantErr: true,
-		},
-		{
 			name:    "Bad path",
-			url:     s.URL,
+			url:     s().URL,
 			path:    "%s%s",
 			want:    nil,
 			wantErr: true,
@@ -108,7 +103,7 @@ func TestPost(t *testing.T) {
 	}{
 		{
 			name:    "OK",
-			url:     s.URL,
+			url:     s().URL,
 			path:    "/",
 			body:    map[string]string{"hakuna": "matata"},
 			want:    []byte("Hi"),
@@ -116,7 +111,7 @@ func TestPost(t *testing.T) {
 		},
 		{
 			name:    "Invalid body",
-			url:     s.URL,
+			url:     s().URL,
 			path:    "/",
 			body:    Post,
 			want:    nil,
@@ -149,7 +144,7 @@ func TestPut(t *testing.T) {
 	}{
 		{
 			name:    "OK",
-			url:     s.URL,
+			url:     s().URL,
 			path:    "/",
 			body:    map[string]string{"hakuna": "matata"},
 			want:    []byte("Hi"),
@@ -157,7 +152,7 @@ func TestPut(t *testing.T) {
 		},
 		{
 			name:    "Invalid body",
-			url:     s.URL,
+			url:     s().URL,
 			path:    "/",
 			body:    Put,
 			want:    nil,
@@ -189,7 +184,7 @@ func TestDelete(t *testing.T) {
 	}{
 		{
 			name:    "OK",
-			url:     s.URL,
+			url:     s().URL,
 			path:    "/",
 			want:    []byte("Hi"),
 			wantErr: false,

--- a/customers/customer_test.go
+++ b/customers/customer_test.go
@@ -26,14 +26,14 @@ func TestCreate(t *testing.T) {
 		useStatus   int
 		useResponse interface{}
 		name        string
-		want        *models.ConektaResponse
+		want        *models.Customer
 		wantErr     bool
 	}{
 		{
 			name:        "OK",
 			useStatus:   200,
-			useResponse: models.ConektaResponse{},
-			want:        &models.ConektaResponse{},
+			useResponse: models.Customer{},
+			want:        &models.Customer{},
 			wantErr:     false,
 		},
 		{
@@ -73,14 +73,14 @@ func TestUpdate(t *testing.T) {
 		useStatus   int
 		useResponse interface{}
 		name        string
-		want        *models.ConektaResponse
+		want        *models.Customer
 		wantErr     bool
 	}{
 		{
 			name:        "OK",
 			useStatus:   200,
-			useResponse: models.ConektaResponse{},
-			want:        &models.ConektaResponse{},
+			useResponse: models.Customer{},
+			want:        &models.Customer{},
 			wantErr:     false,
 		},
 		{
@@ -119,14 +119,14 @@ func TestDelete(t *testing.T) {
 		useStatus   int
 		useResponse interface{}
 		name        string
-		want        *models.ConektaResponse
+		want        *models.Customer
 		wantErr     bool
 	}{
 		{
 			name:        "OK",
 			useStatus:   200,
-			useResponse: models.ConektaResponse{},
-			want:        &models.ConektaResponse{},
+			useResponse: models.Customer{},
+			want:        &models.Customer{},
 			wantErr:     false,
 		},
 		{

--- a/orders/order_test.go
+++ b/orders/order_test.go
@@ -214,3 +214,52 @@ func TestOrderRefund(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateCharge(t *testing.T) {
+	tests := []struct {
+		useStatus       int
+		useResponse     interface{}
+		name            string
+		wantNilResponse bool
+		wantErr         bool
+	}{
+		{
+			name:            "OK",
+			useStatus:       200,
+			useResponse:     models.Charge{},
+			wantNilResponse: false,
+			wantErr:         false,
+		},
+		{
+			name:            "Bad status code (Not 200)",
+			useStatus:       400,
+			useResponse:     nil,
+			wantNilResponse: true,
+			wantErr:         true,
+		},
+		{
+			name:            "Invalid response body (int instead Charge struct)",
+			useStatus:       200,
+			useResponse:     0,
+			wantNilResponse: true,
+			wantErr:         true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := s(tt.useStatus, tt.useResponse)
+			client.SetClientURL(server.URL)
+
+			got, err := CreateCharge("order_id", models.Charge{})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("order.Refund() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if (got == nil) != tt.wantNilResponse {
+				t.Errorf("order.Refund() got = %v, wantNilResponse %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Setup continuous integration using gitlab-ci

## Tests
```
=== RUN   Test_getClient
=== RUN   Test_getClient/OK
--- PASS: Test_getClient (0.00s)
    --- PASS: Test_getClient/OK (0.00s)
=== RUN   TestGet
=== RUN   TestGet/OK
2018/11/14 16:53:28 Calling http://127.0.0.1:42203/
=== RUN   TestGet/Bad_scheme
2018/11/14 16:53:28 Calling bad/
=== RUN   TestGet/Bad_path
--- PASS: TestGet (0.01s)
    --- PASS: TestGet/OK (0.01s)
    --- PASS: TestGet/Bad_scheme (0.00s)
    --- PASS: TestGet/Bad_path (0.00s)
=== RUN   TestPost
=== RUN   TestPost/OK
2018/11/14 16:53:29 Calling http://127.0.0.1:33601/
=== RUN   TestPost/Invalid_body
--- PASS: TestPost (0.00s)
    --- PASS: TestPost/OK (0.00s)
    --- PASS: TestPost/Invalid_body (0.00s)
=== RUN   TestPut
=== RUN   TestPut/OK
2018/11/14 16:53:29 Calling http://127.0.0.1:45561/
=== RUN   TestPut/Invalid_body
--- PASS: TestPut (0.00s)
    --- PASS: TestPut/OK (0.00s)
    --- PASS: TestPut/Invalid_body (0.00s)
=== RUN   TestDelete
=== RUN   TestDelete/OK
2018/11/14 16:53:29 Calling http://127.0.0.1:39035/
--- PASS: TestDelete (0.00s)
    --- PASS: TestDelete/OK (0.00s)
PASS
coverage: 86.2% of statements
ok  	github.com/gustavotero7/go-conekta/client	0.025s	coverage: 86.2% of statements
=== RUN   TestCreate
=== RUN   TestCreate/OK
2018/11/14 16:53:29 Calling http://127.0.0.1:42247/customers
2018/11/14 16:53:29 {}
=== RUN   TestCreate/Bad_status_code_(Not_200)
2018/11/14 16:53:29 Calling http://127.0.0.1:43685/customers
=== RUN   TestCreate/Invalid_response_body_(int_instead_ConektaResponse_struct)
2018/11/14 16:53:29 Calling http://127.0.0.1:38853/customers
2018/11/14 16:53:29 0
--- PASS: TestCreate (0.00s)
    --- PASS: TestCreate/OK (0.00s)
    --- PASS: TestCreate/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestCreate/Invalid_response_body_(int_instead_ConektaResponse_struct) (0.00s)
=== RUN   TestUpdate
=== RUN   TestUpdate/OK
2018/11/14 16:53:29 Calling http://127.0.0.1:40847/customers/
=== RUN   TestUpdate/Bad_status_code_(Not_200)
2018/11/14 16:53:29 Calling http://127.0.0.1:45573/customers/
=== RUN   TestUpdate/Invalid_response_body_(int_instead_ConektaResponse_struct)
2018/11/14 16:53:29 Calling http://127.0.0.1:41747/customers/
--- PASS: TestUpdate (0.00s)
    --- PASS: TestUpdate/OK (0.00s)
    --- PASS: TestUpdate/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestUpdate/Invalid_response_body_(int_instead_ConektaResponse_struct) (0.00s)
=== RUN   TestDelete
=== RUN   TestDelete/OK
2018/11/14 16:53:29 Calling http://127.0.0.1:41089/customers/customer_id
=== RUN   TestDelete/Bad_status_code_(Not_200)
2018/11/14 16:53:29 Calling http://127.0.0.1:34159/customers/customer_id
=== RUN   TestDelete/Invalid_response_body_(int_instead_ConektaResponse_struct)
2018/11/14 16:53:29 Calling http://127.0.0.1:32943/customers/customer_id
--- PASS: TestDelete (0.00s)
    --- PASS: TestDelete/OK (0.00s)
    --- PASS: TestDelete/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestDelete/Invalid_response_body_(int_instead_ConektaResponse_struct) (0.00s)
=== RUN   TestCreateSubscription
=== RUN   TestCreateSubscription/OK
2018/11/14 16:53:29 Calling http://127.0.0.1:43349/customers/customer_id/subscription
=== RUN   TestCreateSubscription/Bad_status_code_(Not_200)
2018/11/14 16:53:29 Calling http://127.0.0.1:34039/customers/customer_id/subscription
=== RUN   TestCreateSubscription/Invalid_response_body_(int_instead_Subscription_struct)
2018/11/14 16:53:29 Calling http://127.0.0.1:39223/customers/customer_id/subscription
--- PASS: TestCreateSubscription (0.00s)
    --- PASS: TestCreateSubscription/OK (0.00s)
    --- PASS: TestCreateSubscription/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestCreateSubscription/Invalid_response_body_(int_instead_Subscription_struct) (0.00s)
=== RUN   TestUpdateSubscription
=== RUN   TestUpdateSubscription/OK
2018/11/14 16:53:29 Calling http://127.0.0.1:39179/customers/customer_id/subscription
=== RUN   TestUpdateSubscription/Bad_status_code_(Not_200)
2018/11/14 16:53:29 Calling http://127.0.0.1:42385/customers/customer_id/subscription
=== RUN   TestUpdateSubscription/Invalid_response_body_(int_instead_Subscription_struct)
2018/11/14 16:53:29 Calling http://127.0.0.1:39415/customers/customer_id/subscription
--- PASS: TestUpdateSubscription (0.00s)
    --- PASS: TestUpdateSubscription/OK (0.00s)
    --- PASS: TestUpdateSubscription/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestUpdateSubscription/Invalid_response_body_(int_instead_Subscription_struct) (0.00s)
=== RUN   TestPauseSubscription
=== RUN   TestPauseSubscription/OK
2018/11/14 16:53:29 Calling http://127.0.0.1:46395/customers/customer_id/subscription/pause
=== RUN   TestPauseSubscription/Bad_status_code_(Not_200)
2018/11/14 16:53:29 Calling http://127.0.0.1:44409/customers/customer_id/subscription/pause
=== RUN   TestPauseSubscription/Invalid_response_body_(int_instead_Subscription_struct)
2018/11/14 16:53:29 Calling http://127.0.0.1:38423/customers/customer_id/subscription/pause
--- PASS: TestPauseSubscription (0.00s)
    --- PASS: TestPauseSubscription/OK (0.00s)
    --- PASS: TestPauseSubscription/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestPauseSubscription/Invalid_response_body_(int_instead_Subscription_struct) (0.00s)
=== RUN   TestResumeSubscription
=== RUN   TestResumeSubscription/OK
2018/11/14 16:53:29 Calling http://127.0.0.1:37069/customers/customer_id/subscription/resume
=== RUN   TestResumeSubscription/Bad_status_code_(Not_200)
2018/11/14 16:53:29 Calling http://127.0.0.1:38895/customers/customer_id/subscription/resume
=== RUN   TestResumeSubscription/Invalid_response_body_(int_instead_Subscription_struct)
2018/11/14 16:53:29 Calling http://127.0.0.1:34307/customers/customer_id/subscription/resume
--- PASS: TestResumeSubscription (0.00s)
    --- PASS: TestResumeSubscription/OK (0.00s)
    --- PASS: TestResumeSubscription/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestResumeSubscription/Invalid_response_body_(int_instead_Subscription_struct) (0.00s)
=== RUN   TestCancelSubscription
=== RUN   TestCancelSubscription/OK
2018/11/14 16:53:29 Calling http://127.0.0.1:37863/customers/customer_id/subscription/cancel
=== RUN   TestCancelSubscription/Bad_status_code_(Not_200)
2018/11/14 16:53:29 Calling http://127.0.0.1:38427/customers/customer_id/subscription/cancel
=== RUN   TestCancelSubscription/Invalid_response_body_(int_instead_Subscription_struct)
2018/11/14 16:53:29 Calling http://127.0.0.1:32795/customers/customer_id/subscription/cancel
--- PASS: TestCancelSubscription (0.00s)
    --- PASS: TestCancelSubscription/OK (0.00s)
    --- PASS: TestCancelSubscription/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestCancelSubscription/Invalid_response_body_(int_instead_Subscription_struct) (0.00s)
=== RUN   TestCreatePaymentSource
=== RUN   TestCreatePaymentSource/OK
2018/11/14 16:53:29 Calling http://127.0.0.1:43219/customers/customer_id/payment_sources
=== RUN   TestCreatePaymentSource/Bad_status_code_(Not_200)
2018/11/14 16:53:29 Calling http://127.0.0.1:39363/customers/customer_id/payment_sources
=== RUN   TestCreatePaymentSource/Invalid_response_body_(int_instead_PaymentSource_struct)
2018/11/14 16:53:29 Calling http://127.0.0.1:46457/customers/customer_id/payment_sources
--- PASS: TestCreatePaymentSource (0.00s)
    --- PASS: TestCreatePaymentSource/OK (0.00s)
    --- PASS: TestCreatePaymentSource/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestCreatePaymentSource/Invalid_response_body_(int_instead_PaymentSource_struct) (0.00s)
=== RUN   TestDeletePaymentSource
=== RUN   TestDeletePaymentSource/OK
2018/11/14 16:53:29 Calling http://127.0.0.1:39121/customers/customer_id/payment_sources/payment_source_id
=== RUN   TestDeletePaymentSource/Bad_status_code_(Not_200)
2018/11/14 16:53:29 Calling http://127.0.0.1:44221/customers/customer_id/payment_sources/payment_source_id
=== RUN   TestDeletePaymentSource/Invalid_response_body_(int_instead_PaymentSource_struct)
2018/11/14 16:53:29 Calling http://127.0.0.1:34981/customers/customer_id/payment_sources/payment_source_id
--- PASS: TestDeletePaymentSource (0.00s)
    --- PASS: TestDeletePaymentSource/OK (0.00s)
    --- PASS: TestDeletePaymentSource/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestDeletePaymentSource/Invalid_response_body_(int_instead_PaymentSource_struct) (0.00s)
PASS
coverage: 100.0% of statements
ok  	github.com/gustavotero7/go-conekta/customers	0.030s	coverage: 100.0% of statements
?   	github.com/gustavotero7/go-conekta/example	[no test files]
=== RUN   TestConektaError_Error
=== RUN   TestConektaError_Error/OK
--- PASS: TestConektaError_Error (0.00s)
    --- PASS: TestConektaError_Error/OK (0.00s)
PASS
coverage: 100.0% of statements
ok  	github.com/gustavotero7/go-conekta/models	0.004s	coverage: 100.0% of statements
=== RUN   TestOrderCreate
=== RUN   TestOrderCreate/OK
2018/11/14 16:53:31 Calling http://127.0.0.1:34183/orders
=== RUN   TestOrderCreate/Bad_status_code_(Not_200)
2018/11/14 16:53:31 Calling http://127.0.0.1:35491/orders
=== RUN   TestOrderCreate/Invalid_response_body_(int_instead_Order_struct)
2018/11/14 16:53:31 Calling http://127.0.0.1:43645/orders
--- PASS: TestOrderCreate (0.00s)
    --- PASS: TestOrderCreate/OK (0.00s)
    --- PASS: TestOrderCreate/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestOrderCreate/Invalid_response_body_(int_instead_Order_struct) (0.00s)
=== RUN   TestOrderUpdate
=== RUN   TestOrderUpdate/OK
2018/11/14 16:53:31 Calling http://127.0.0.1:33977/orders/
=== RUN   TestOrderUpdate/Bad_status_code_(Not_200)
2018/11/14 16:53:31 Calling http://127.0.0.1:46081/orders/
=== RUN   TestOrderUpdate/Invalid_response_body_(int_instead_Order_struct)
2018/11/14 16:53:31 Calling http://127.0.0.1:42913/orders/
--- PASS: TestOrderUpdate (0.00s)
    --- PASS: TestOrderUpdate/OK (0.00s)
    --- PASS: TestOrderUpdate/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestOrderUpdate/Invalid_response_body_(int_instead_Order_struct) (0.00s)
=== RUN   TestOrderCapture
=== RUN   TestOrderCapture/OK
2018/11/14 16:53:31 Calling http://127.0.0.1:45171/orders/order_id/capture
=== RUN   TestOrderCapture/Bad_status_code_(Not_200)
2018/11/14 16:53:31 Calling http://127.0.0.1:39225/orders/order_id/capture
=== RUN   TestOrderCapture/Invalid_response_body_(int_instead_Order_struct)
2018/11/14 16:53:31 Calling http://127.0.0.1:41275/orders/order_id/capture
--- PASS: TestOrderCapture (0.00s)
    --- PASS: TestOrderCapture/OK (0.00s)
    --- PASS: TestOrderCapture/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestOrderCapture/Invalid_response_body_(int_instead_Order_struct) (0.00s)
=== RUN   TestOrderRefund
=== RUN   TestOrderRefund/OK
2018/11/14 16:53:31 Calling http://127.0.0.1:41031/orders//refunds
=== RUN   TestOrderRefund/Bad_status_code_(Not_200)
2018/11/14 16:53:31 Calling http://127.0.0.1:42433/orders//refunds
=== RUN   TestOrderRefund/Invalid_response_body_(int_instead_Order_struct)
2018/11/14 16:53:31 Calling http://127.0.0.1:40413/orders//refunds
--- PASS: TestOrderRefund (0.00s)
    --- PASS: TestOrderRefund/OK (0.00s)
    --- PASS: TestOrderRefund/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestOrderRefund/Invalid_response_body_(int_instead_Order_struct) (0.00s)
=== RUN   TestCreateCharge
=== RUN   TestCreateCharge/OK
2018/11/14 16:53:31 Calling http://127.0.0.1:37885/orders/order_id/charges
=== RUN   TestCreateCharge/Bad_status_code_(Not_200)
2018/11/14 16:53:31 Calling http://127.0.0.1:44459/orders/order_id/charges
=== RUN   TestCreateCharge/Invalid_response_body_(int_instead_Charge_struct)
2018/11/14 16:53:31 Calling http://127.0.0.1:40759/orders/order_id/charges
--- PASS: TestCreateCharge (0.00s)
    --- PASS: TestCreateCharge/OK (0.00s)
    --- PASS: TestCreateCharge/Bad_status_code_(Not_200) (0.00s)
    --- PASS: TestCreateCharge/Invalid_response_body_(int_instead_Charge_struct) (0.00s)
PASS
coverage: 100.0% of statements
ok  	github.com/gustavotero7/go-conekta/orders	0.018s	coverage: 100.0% of statements
```